### PR TITLE
Ontoportal align:  Store daemon options in Redis

### DIFF
--- a/bin/ncbo_cron
+++ b/bin/ncbo_cron
@@ -214,6 +214,9 @@ runner.execute do |opts|
   redis = Redis.new(host: opts[:redis_host], port: opts[:redis_port])
   puts "Running ncbo_cron with redis: #{redis.inspect}"
 
+  # Store daemon options in Redis (only if called in daemonized mode)
+  redis.set("cron:daemon:options", options.to_h.to_json) if options[:daemonize]
+
   # If we're viewing queued entries, show them and quit
   if opts[:view_queue]
     parser = NcboCron::Models::OntologySubmissionParser.new

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -74,7 +74,7 @@ module NcboCron
 
         last.bring(:uploadFilePath) if last.bring?(:uploadFilePath)
 
-        if self.not_pull_submission(last, ont, isLong, enable_pull_umls, options)
+        if not_pull_submission(last, ont, isLong, enable_pull_umls, options)
           raise StandardError, "Pull umls not enabled"
         end
 


### PR DESCRIPTION
### Context  
This PR makes the ncbo_conr daemon save its process data in Redis so that the API (https://github.com/lifewatch-eric/ontologies_api/pull/6) can access it.

### Changes

-  store daemon options in Redis (https://github.com/lifewatch-eric/ncbo_cron/pull/2/commits/0bd9db2403847721bf402129a8c69daf09590b8d)